### PR TITLE
Add support of proxy_logs option

### DIFF
--- a/lib/Ubic/Service/ServerStarter.pm
+++ b/lib/Ubic/Service/ServerStarter.pm
@@ -24,6 +24,7 @@ sub new {
         env         => { type => HASHREF, optional => 1 },
         stdout      => { type => SCALAR, optional => 1 },
         stderr      => { type => SCALAR, optional => 1 },
+        proxy_logs  => { type => BOOLEAN, optional => 1 },
         pidfile     => { type => SCALAR, optional => 1 },
         cwd         => { type => SCALAR, optional => 1 },
     });
@@ -76,7 +77,7 @@ sub start_impl {
         pidfile => $self->pidfile,
         term_timeout => 5, # TODO - configurable?
     };
-    for (qw/ env cwd stdout stderr ubic_log /) {
+    for (qw/ env cwd stdout stderr ubic_log /, ($Ubic::Daemon::VERSION gt '1.48' ? 'proxy_logs' : ())) {
         $daemon_opts->{$_} = $self->{$_} if defined $self->{$_};
     }
     start_daemon($daemon_opts);
@@ -197,6 +198,12 @@ Path to stdout log.
 =item I<stderr>
 
 Path to stderr log.
+
+=item I<proxy_logs>
+
+Boolean flag. If enabled, C<ubic-guardian> will replace daemon's stdout and
+stderr filehandles with pipes, proxy all data to the log files, and reopen
+them on C<SIGHUP>.
 
 =item I<user>
 


### PR DESCRIPTION
This patch added support of proxy_logs parameter that was implemented in Ubic 1.48_01.
